### PR TITLE
Implement JSON parser for party configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ dependencies {
 
 	compileOnly 'org.projectlombok:lombok'
 
-	implementation 'org.springframework.boot:spring-boot-starter'
-	//implementation 'com.fasterxml.jackson.core:jackson-databind'
+        implementation 'org.springframework.boot:spring-boot-starter'
+        implementation 'com.fasterxml.jackson.core:jackson-databind'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.projectlombok:lombok'

--- a/src/main/java/com/redshift/ShadowDarkCalculator/actions/spells/SpellBuilder.java
+++ b/src/main/java/com/redshift/ShadowDarkCalculator/actions/spells/SpellBuilder.java
@@ -1,0 +1,23 @@
+package com.redshift.ShadowDarkCalculator.actions.spells;
+
+import java.util.function.Supplier;
+
+public enum SpellBuilder {
+    TURN_UNDEAD(TurnUndead::new),
+    CURE_WOUNDS(CureWounds::new),
+    SHIELD_OF_FAITH(ShieldOfFaith::new),
+    SLEEP(Sleep::new),
+    MAGIC_MISSILE(MagicMissile::new),
+    BURNING_HANDS(BurningHands::new);
+
+    private final Supplier<Spell> ctor;
+
+    SpellBuilder(Supplier<Spell> ctor) {
+        this.ctor = ctor;
+    }
+
+    public Spell build() {
+        return ctor.get();
+    }
+}
+

--- a/src/main/java/com/redshift/ShadowDarkCalculator/party/JsonPartyConfig.java
+++ b/src/main/java/com/redshift/ShadowDarkCalculator/party/JsonPartyConfig.java
@@ -1,0 +1,161 @@
+package com.redshift.ShadowDarkCalculator.party;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redshift.ShadowDarkCalculator.actions.Action;
+import com.redshift.ShadowDarkCalculator.actions.PerformOneAction;
+import com.redshift.ShadowDarkCalculator.actions.spells.*;
+import com.redshift.ShadowDarkCalculator.actions.weapons.Weapon;
+import com.redshift.ShadowDarkCalculator.actions.weapons.WeaponBuilder;
+import com.redshift.ShadowDarkCalculator.creatures.Creature;
+import com.redshift.ShadowDarkCalculator.creatures.Label;
+import com.redshift.ShadowDarkCalculator.creatures.Player;
+import com.redshift.ShadowDarkCalculator.creatures.Stats;
+import com.redshift.ShadowDarkCalculator.targets.FocusFireTargetSelector;
+import com.redshift.ShadowDarkCalculator.targets.SingleTargetSelector;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reads a JSON document describing a party and creates the associated creatures.
+ */
+public class JsonPartyConfig implements PartyBuilder {
+
+    private final String json;
+    private final List<Creature> creatures = new ArrayList<>();
+
+    public JsonPartyConfig(String json) {
+        this.json = json;
+    }
+
+    @Override
+    public PartyBuilder add(Creature creature) {
+        creatures.add(creature);
+        return this;
+    }
+
+    @Override
+    public List<Creature> build() {
+        if (creatures.isEmpty()) {
+            parseJson();
+        }
+        return creatures;
+    }
+
+    private void parseJson() {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            JsonNode root = mapper.readTree(json);
+            if (root.isArray()) {
+                for (JsonNode node : root) {
+                    creatures.add(parseCreature(node));
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse party JSON", e);
+        }
+    }
+
+    private Creature parseCreature(JsonNode node) {
+        String name = node.path("name").asText();
+        int level = node.path("level").asInt();
+
+        JsonNode statsNode = node.path("stats");
+        Stats stats = new Stats(
+                statsNode.path("strength").asInt(),
+                statsNode.path("dexterity").asInt(),
+                statsNode.path("constitution").asInt(),
+                statsNode.path("intelligence").asInt(),
+                statsNode.path("wisdom").asInt(),
+                statsNode.path("charisma").asInt()
+        );
+
+        int armorClass = node.path("armorClass").asInt();
+        int hitPoints = node.path("hitPoints").asInt();
+
+        List<Action> actions = new ArrayList<>();
+        JsonNode actionsNode = node.path("actions");
+        if (actionsNode.isArray()) {
+            for (JsonNode actionNode : actionsNode) {
+                actions.add(parseAction(actionNode));
+            }
+        }
+
+        Action action = actions.size() == 1 ? actions.get(0) : new PerformOneAction(actions);
+        SingleTargetSelector selector = parseSelector(node.path("targetSelector").asText());
+
+        Creature creature = new Player(name, level, stats, armorClass, hitPoints, action, selector);
+
+        JsonNode labelsNode = node.path("labels");
+        if (labelsNode.isArray()) {
+            for (JsonNode labelNode : labelsNode) {
+                try {
+                    creature.getLabels().add(Label.valueOf(labelNode.asText()));
+                } catch (IllegalArgumentException ignored) {
+                    // Unknown labels are ignored
+                }
+            }
+        }
+
+        return creature;
+    }
+
+    private Action parseAction(JsonNode node) {
+        String type = node.path("type").asText();
+        if ("weapon".equalsIgnoreCase(type)) {
+            WeaponBuilder builder = mapWeapon(node.path("weapon").asText());
+            int attackBonus = node.path("attackBonus").asInt(0);
+            int damageBonus = node.path("damageBonus").asInt(0);
+            boolean magical = node.path("magical").asBoolean(false);
+            boolean silvered = node.path("silvered").asBoolean(false);
+            int priority = node.path("priority").asInt(1);
+
+            return builder.build(attackBonus, damageBonus, magical, silvered, priority);
+        } else if ("spell".equalsIgnoreCase(type)) {
+            Spell spell = mapSpell(node.path("name").asText());
+            int bonus = node.path("bonus").asInt(0);
+            if (bonus != 0) {
+                spell.addBonus(bonus);
+            }
+            if (node.path("advantage").asBoolean(false)) {
+                spell.addAdvantage();
+            }
+            spell.setPriority(node.path("priority").asInt(1));
+            return spell;
+        }
+        throw new IllegalArgumentException("Unknown action type: " + type);
+    }
+
+    private WeaponBuilder mapWeapon(String weaponName) {
+        return switch (weaponName) {
+            case "Bastard Sword 1h" -> WeaponBuilder.BASTARD_SWORD_1H;
+            case "Longsword" -> WeaponBuilder.LONGSWORD;
+            case "Staff" -> WeaponBuilder.STAFF;
+            case "Crossbow" -> WeaponBuilder.CROSSBOW;
+            default -> throw new IllegalArgumentException("Unknown weapon: " + weaponName);
+        };
+    }
+
+    private Spell mapSpell(String name) {
+        return switch (name) {
+            case "Turn Undead" -> new TurnUndead();
+            case "Cure Wounds" -> new CureWounds();
+            case "Shield Of Faith" -> new ShieldOfFaith();
+            case "Sleep" -> new Sleep();
+            case "Magic Missile" -> new MagicMissile();
+            case "Burning Hands" -> new BurningHands();
+            default -> throw new IllegalArgumentException("Unknown spell: " + name);
+        };
+    }
+
+    private SingleTargetSelector parseSelector(String selector) {
+        if ("FocusFire".equalsIgnoreCase(selector)) {
+            return new FocusFireTargetSelector();
+        }
+        // Default selector
+        return new FocusFireTargetSelector();
+    }
+}
+

--- a/src/main/java/com/redshift/ShadowDarkCalculator/targets/TargetSelectorBuilder.java
+++ b/src/main/java/com/redshift/ShadowDarkCalculator/targets/TargetSelectorBuilder.java
@@ -1,0 +1,20 @@
+package com.redshift.ShadowDarkCalculator.targets;
+
+import java.util.function.Supplier;
+
+public enum TargetSelectorBuilder {
+    FOCUS_FIRE(FocusFireTargetSelector::new),
+    RANDOM(RandomTargetSelector::new),
+    HEAL(HealTargetSelector::new);
+
+    private final Supplier<SingleTargetSelector> ctor;
+
+    TargetSelectorBuilder(Supplier<SingleTargetSelector> ctor) {
+        this.ctor = ctor;
+    }
+
+    public SingleTargetSelector build() {
+        return ctor.get();
+    }
+}
+

--- a/src/test/java/com/redshift/ShadowDarkCalculator/party/JsonPartyConfigTest.java
+++ b/src/test/java/com/redshift/ShadowDarkCalculator/party/JsonPartyConfigTest.java
@@ -1,0 +1,115 @@
+package com.redshift.ShadowDarkCalculator.party;
+
+import com.redshift.ShadowDarkCalculator.creatures.Creature;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JsonPartyConfigTest {
+
+    @Test
+    void build_fromJson_shouldReturnCreatures() {
+        // Build the expected party using the builder
+        List<Creature> expected = new TheCrabCrushersBuilderv2().build();
+
+        String json = """
+            [
+              {
+                "name": "Karn Crabcrusher",
+                "level": 1,
+                "stats": {
+                  "strength": 15,
+                  "dexterity": 14,
+                  "constitution": 14,
+                  "intelligence": 14,
+                  "wisdom": 11,
+                  "charisma": 14
+                },
+                "armorClass": 15,
+                "hitPoints": 7,
+                "actions": [
+                  {
+                    "type": "weapon",
+                    "weapon": "Bastard Sword 1h",
+                    "attackBonus": 3,
+                    "damageBonus": 2
+                  }
+                ],
+                "targetSelector": "FocusFire",
+                "labels": ["BRUTE", "PLAYER"]
+              },
+              {
+                "name": "Kabsal Argent",
+                "level": 1,
+                "stats": {
+                  "strength": 15,
+                  "dexterity": 9,
+                  "constitution": 13,
+                  "intelligence": 10,
+                  "wisdom": 17,
+                  "charisma": 12
+                },
+                "armorClass": 12,
+                "hitPoints": 7,
+                "actions": [
+                  {"type": "weapon", "weapon": "Longsword", "attackBonus": 1},
+                  {"type": "spell", "name": "Turn Undead", "bonus": 1, "priority": 4},
+                  {"type": "spell", "name": "Cure Wounds", "bonus": 1, "priority": 2},
+                  {"type": "spell", "name": "Shield Of Faith", "bonus": 1}
+                ],
+                "targetSelector": "FocusFire",
+                "labels": ["HEALER", "PLAYER"]
+              },
+              {
+                "name": "Alderon",
+                "level": 1,
+                "stats": {
+                  "strength": 8,
+                  "dexterity": 13,
+                  "constitution": 12,
+                  "intelligence": 16,
+                  "wisdom": 10,
+                  "charisma": 8
+                },
+                "armorClass": 11,
+                "hitPoints": 2,
+                "actions": [
+                  {"type": "weapon", "weapon": "Staff"},
+                  {"type": "spell", "name": "Sleep", "bonus": 1, "priority": 3},
+                  {"type": "spell", "name": "Magic Missile", "bonus": 1, "advantage": true, "priority": 2},
+                  {"type": "spell", "name": "Burning Hands", "bonus": 1, "advantage": true, "priority": 4}
+                ],
+                "targetSelector": "FocusFire",
+                "labels": ["BACKLINE", "CASTER", "PLAYER"]
+              },
+              {
+                "name": "Fennick Quickfoot",
+                "level": 1,
+                "stats": {
+                  "strength": 10,
+                  "dexterity": 10,
+                  "constitution": 14,
+                  "intelligence": 8,
+                  "wisdom": 10,
+                  "charisma": 8
+                },
+                "armorClass": 14,
+                "hitPoints": 6,
+                "actions": [
+                  {"type": "weapon", "weapon": "Crossbow"}
+                ],
+                "targetSelector": "FocusFire",
+                "labels": ["BACKLINE", "PLAYER"]
+              }
+            ]
+            """;
+
+        JsonPartyConfig config = new JsonPartyConfig(json);
+        List<Creature> actual = config.build();
+
+        // Expect same number of creatures
+        assertEquals(expected.size(), actual.size(), "Creature count should match parsed JSON");
+    }
+}

--- a/src/test/java/com/redshift/ShadowDarkCalculator/party/JsonPartyConfigTest.java
+++ b/src/test/java/com/redshift/ShadowDarkCalculator/party/JsonPartyConfigTest.java
@@ -32,12 +32,12 @@ public class JsonPartyConfigTest {
                 "actions": [
                   {
                     "type": "weapon",
-                    "weapon": "Bastard Sword 1h",
+                    "weapon": "BASTARD_SWORD_1H",
                     "attackBonus": 3,
                     "damageBonus": 2
                   }
                 ],
-                "targetSelector": "FocusFire",
+                "targetSelector": "FOCUS_FIRE",
                 "labels": ["BRUTE", "PLAYER"]
               },
               {
@@ -54,12 +54,12 @@ public class JsonPartyConfigTest {
                 "armorClass": 12,
                 "hitPoints": 7,
                 "actions": [
-                  {"type": "weapon", "weapon": "Longsword", "attackBonus": 1},
-                  {"type": "spell", "name": "Turn Undead", "bonus": 1, "priority": 4},
-                  {"type": "spell", "name": "Cure Wounds", "bonus": 1, "priority": 2},
-                  {"type": "spell", "name": "Shield Of Faith", "bonus": 1}
+                  {"type": "weapon", "weapon": "LONGSWORD", "attackBonus": 1},
+                  {"type": "spell", "name": "TURN_UNDEAD", "bonus": 1, "priority": 4},
+                  {"type": "spell", "name": "CURE_WOUNDS", "bonus": 1, "priority": 2},
+                  {"type": "spell", "name": "SHIELD_OF_FAITH", "bonus": 1}
                 ],
-                "targetSelector": "FocusFire",
+                "targetSelector": "FOCUS_FIRE",
                 "labels": ["HEALER", "PLAYER"]
               },
               {
@@ -76,12 +76,12 @@ public class JsonPartyConfigTest {
                 "armorClass": 11,
                 "hitPoints": 2,
                 "actions": [
-                  {"type": "weapon", "weapon": "Staff"},
-                  {"type": "spell", "name": "Sleep", "bonus": 1, "priority": 3},
-                  {"type": "spell", "name": "Magic Missile", "bonus": 1, "advantage": true, "priority": 2},
-                  {"type": "spell", "name": "Burning Hands", "bonus": 1, "advantage": true, "priority": 4}
+                  {"type": "weapon", "weapon": "STAFF"},
+                  {"type": "spell", "name": "SLEEP", "bonus": 1, "priority": 3},
+                  {"type": "spell", "name": "MAGIC_MISSILE", "bonus": 1, "advantage": true, "priority": 2},
+                  {"type": "spell", "name": "BURNING_HANDS", "bonus": 1, "advantage": true, "priority": 4}
                 ],
-                "targetSelector": "FocusFire",
+                "targetSelector": "FOCUS_FIRE",
                 "labels": ["BACKLINE", "CASTER", "PLAYER"]
               },
               {
@@ -98,9 +98,9 @@ public class JsonPartyConfigTest {
                 "armorClass": 14,
                 "hitPoints": 6,
                 "actions": [
-                  {"type": "weapon", "weapon": "Crossbow"}
+                  {"type": "weapon", "weapon": "CROSSBOW"}
                 ],
-                "targetSelector": "FocusFire",
+                "targetSelector": "FOCUS_FIRE",
                 "labels": ["BACKLINE", "PLAYER"]
               }
             ]


### PR DESCRIPTION
## Summary
- make jackson-databind a compile dependency
- implement JSON parsing logic in `JsonPartyConfig`
- keep JSON fixture in the unit test

## Testing
- `./gradlew test --tests com.redshift.ShadowDarkCalculator.party.JsonPartyConfigTest --console=plain --rerun-tasks`

------
https://chatgpt.com/codex/tasks/task_e_684064a297288329ad4f7d0faae4ffac